### PR TITLE
bug fix to unitarity check in Time-Evolution-SV notebook

### DIFF
--- a/notebooks/Time-Evolution-SV.ipynb
+++ b/notebooks/Time-Evolution-SV.ipynb
@@ -174,7 +174,7 @@
    ],
    "source": [
     "# Check that all probabilities sum to 1 at each time step\n",
-    "np.all(np.sum(trajectories_gc, axis=1))"
+    "np.all(np.isclose(np.sum(trajectories_gc, axis=1),1.))"
    ]
   },
   {
@@ -242,7 +242,7 @@
    ],
    "source": [
     "# Check that all probabilities sum to 1 at each time step\n",
-    "np.all(np.sum(trajectories_jw, axis=1))"
+    "np.all(np.isclose(np.sum(trajectories_jw, axis=1),1.))"
    ]
   },
   {


### PR DESCRIPTION
any nonzero value of np.sum() will be truthy, need to compare to 1 explicitly